### PR TITLE
Improve source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "cross-env NODE_ENV=production && node ./webpack/build",
+    "build": "cross-env NODE_ENV=production node ./webpack/build",
     "watch": "node ./webpack/watch",
-    "build:dev": "cross-env NODE_ENV=development && node ./webpack/build"
+    "build:dev": "cross-env NODE_ENV=development node ./webpack/build"
   },
   "devDependencies": {
     "@types/assert": "^1.4.6",

--- a/webpack/build.js
+++ b/webpack/build.js
@@ -5,6 +5,7 @@ const { argv } = process;
 // eslint-disable-next-line no-unused-vars
 const [node, path, ...packages] = argv;
 const isDebug = process.env.NODE_ENV !== 'production';
+console.log(process.env.NODE_ENV, isDebug);
 const cmd = isDebug ? 'build:dev' : 'build';
 const allPackages = readdirSync('./packages');
 const firstToGo = ['core'];

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -6,7 +6,7 @@ const plugins = require('./plugins');
 module.exports = {
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
 
-  devtool: process.env.NODE_ENV === 'production' ? 'source-map' : 'source-map',
+  devtool: process.env.NODE_ENV === 'production' ? 'source-map' : 'cheap-source-map',
 
   entry: {},
 

--- a/webpack/loaders.js
+++ b/webpack/loaders.js
@@ -1,3 +1,14 @@
+const path = require('path');
+const { readdirSync } = require('fs');
+
+const makeIncludeFunction = () => {
+  // console.log(path.join(__dirname,'..', '/packages'));
+  const allPackages = readdirSync(path.join(__dirname, '..', '/packages'));
+  // console.log(allPackages);
+  return (p) => p.indexOf('@spiral-toolkit') >= 0
+        || !!allPackages.find((pack) => p.indexOf(`packages${path.sep}${pack}`) >= 0);
+};
+
 function makeUrlLoader(pattern) {
   return {
     test: pattern,
@@ -13,6 +24,7 @@ exports.jsmap = {
   use: [
     'source-map-loader',
   ],
+  include: makeIncludeFunction(),
   enforce: 'pre',
 };
 
@@ -31,7 +43,7 @@ exports.js = {
   options: {
     transpileOnly: true,
   },
-}; 
+};
 
 exports.ts = {
   test: /\.tsx?$/,

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -3,7 +3,7 @@ const webpack = require('webpack');
 
 /* const sourceMap = process.env.TEST || process.env.NODE_ENV !== 'production'
   ? [new webpack.SourceMapDevToolPlugin({
-    exclude: ['luxon', '@types/luxon'],
+    exclude: [/luxon/],
     filename: '[name].js.map',
   })]
   : [new webpack.SourceMapDevToolPlugin({

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -1,9 +1,16 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const webpack = require('webpack');
 
-const sourceMap = process.env.TEST || process.env.NODE_ENV !== 'production'
-  ? [new webpack.SourceMapDevToolPlugin({ filename: null, test: /\.js$/ })]
-  : [];
+/* const sourceMap = process.env.TEST || process.env.NODE_ENV !== 'production'
+  ? [new webpack.SourceMapDevToolPlugin({
+    exclude: ['luxon', '@types/luxon'],
+    filename: '[name].js.map',
+  })]
+  : [new webpack.SourceMapDevToolPlugin({
+    exclude: ['luxon', '@types/luxon'],
+    filename: '[name].js.map',
+  })]; */
+
 
 const basePlugins = [
   new webpack.DefinePlugin({
@@ -16,7 +23,7 @@ const basePlugins = [
   }),
   // eslint-disable-next-line no-useless-escape
   new webpack.ContextReplacementPlugin(/moment[\/\\]locale/, /en/),
-].concat(sourceMap);
+];// .concat(sourceMap);
 
 const devPlugins = [];
 


### PR DESCRIPTION
1. using both devtool and SourceMapPlugin processes source-maps twice - removed.

2. source map loader is now loading only our packages, ignoring vendors

3. dev maps switched to 'cheap' version